### PR TITLE
exposed volume meshing related meshing parameters

### DIFF
--- a/nglib/nglib.cpp
+++ b/nglib/nglib.cpp
@@ -1116,7 +1116,7 @@ namespace nglib
         mparam.meshsizefilename = meshsize_filename;
       else
         mparam.meshsizefilename = "";
-        
+
       mparam.optsteps2d = optsteps_2d;
       mparam.optsteps3d = optsteps_3d;
 
@@ -1144,6 +1144,9 @@ namespace nglib
       stlparam.resthlinelengthfac = linelengthfact;
 
       stldoctor.geom_tol_fact = stlgeom_tol_fact;
+
+      if(closeedgeenable)
+         mparam.closeedgefac = closeedgefact;
    }
    // ------------------ End - Meshing Parameters related functions --------------------
 

--- a/nglib/nglib.cpp
+++ b/nglib/nglib.cpp
@@ -1014,8 +1014,16 @@ namespace nglib
       check_overlap = 1;
       check_overlapping_boundary = 1;
 
-      parthreadenable = 0;
+      parallel_meshing = 1;
       nthreads = 4;
+      
+      opterrpow = 2;
+      delaunayenable = 1;
+      blockfillenable = 1;
+      blockfilldist = 0.1;
+      maxoutersteps = 10;
+      only3D_domain_nr = 0;
+      try_hexes = 0;
 
       surfcurvfact = 2;
       chartdistfact = 1.2;
@@ -1066,8 +1074,16 @@ namespace nglib
       check_overlap = 1;
       check_overlapping_boundary = 1;
 
-      parthreadenable = 0;
+      parallel_meshing = 1;
       nthreads = 4;
+      
+      opterrpow = 2;
+      delaunayenable = 1;
+      blockfillenable = 1;
+      blockfilldist = 0.1;
+      maxoutersteps = 10;
+      only3D_domain_nr = 0;
+      try_hexes = 0;
 
       surfcurvfact = 2;
       chartdistfact = 1.2;
@@ -1100,6 +1116,7 @@ namespace nglib
         mparam.meshsizefilename = meshsize_filename;
       else
         mparam.meshsizefilename = "";
+        
       mparam.optsteps2d = optsteps_2d;
       mparam.optsteps3d = optsteps_3d;
 
@@ -1109,8 +1126,16 @@ namespace nglib
       mparam.checkoverlap = check_overlap;
       mparam.checkoverlappingboundary = check_overlapping_boundary;
 
-      mparam.parthread = parthreadenable;
+      mparam.parallel_meshing = parallel_meshing;
       mparam.nthreads = nthreads;
+      
+      mparam.opterrpow = opterrpow;
+      mparam.delaunay = delaunayenable;
+      mparam.blockfill = blockfillenable;
+      mparam.filldist = blockfilldist;
+      mparam.maxoutersteps = maxoutersteps;
+      mparam.only3D_domain_nr = only3D_domain_nr;
+      mparam.try_hexes = try_hexes;
 
       stlparam.resthsurfcurvfac = surfcurvfact;
       stlparam.resthchartdistfac = chartdistfact;

--- a/nglib/nglib.h
+++ b/nglib/nglib.h
@@ -185,7 +185,7 @@ public:
       - #blockfilldist = 0.1
       - maxoutersteps = 10
       - only3D_domain_nr = 0
-      - try_hexes = 1
+      - try_hexes = 0
       - #surfcurvfact: 2
       - #chartdistfact: 1.2
       - #edgeanglefact: 1

--- a/nglib/nglib.h
+++ b/nglib/nglib.h
@@ -133,8 +133,16 @@ public:
    // Nikhil - 29/09/2020
    // Added a couple more parameters into the meshing parameters list
    // from Netgen into Nglib
-   int parthreadenable;                 //!< Enable / Disable parallel threads
+   int parallel_meshing;                //!< Enable / Disable parallel meshing
    int nthreads;                        //!< Set number of threads to use
+   
+   double opterrpow;
+   int delaunayenable;                  //!< Enable / Disable delaunay
+   int blockfillenable;                 //!< Enable / Disable block fill
+   double blockfilldist;                //!< Enable / Disable block fill distance
+   int maxoutersteps;                   //!< Set max number of outer steps
+   int only3D_domain_nr;                
+   int try_hexes;                       //!< Enable / Disable hex-meshing
 
    double surfcurvfact;                 //!< Set STL - surface curvature
    double chartdistfact;                //!< Set STL - chart distance
@@ -169,7 +177,7 @@ public:
       - #invert_trigs:0 
       - #check_overlap: 1
       - #check_overlapping_boundary: 1
-      - #parthreadenable: 0
+      - #parallel_meshing: 1
       - #nthreads: 4
       - #surfcurvfact: 2
       - #chartdistfact: 1.2

--- a/nglib/nglib.h
+++ b/nglib/nglib.h
@@ -136,12 +136,12 @@ public:
    int parallel_meshing;                //!< Enable / Disable parallel meshing
    int nthreads;                        //!< Set number of threads to use
    
-   double opterrpow;
+   double opterrpow;                    //!< Set power of error (to approximate max err optimization)
    int delaunayenable;                  //!< Enable / Disable delaunay
    int blockfillenable;                 //!< Enable / Disable block fill
    double blockfilldist;                //!< Enable / Disable block fill distance
    int maxoutersteps;                   //!< Set max number of outer steps
-   int only3D_domain_nr;                
+   int only3D_domain_nr;                //!< Select domain to perform volume meshing ignoring others. (0 => ignore none)
    int try_hexes;                       //!< Enable / Disable hex-meshing
 
    double surfcurvfact;                 //!< Set STL - surface curvature
@@ -179,6 +179,13 @@ public:
       - #check_overlapping_boundary: 1
       - #parallel_meshing: 1
       - #nthreads: 4
+      - #opterrpow: 2
+      - #delaunayenable: 1
+      - #blockfillenable = 1
+      - #blockfilldist = 0.1
+      - maxoutersteps = 10
+      - only3D_domain_nr = 0
+      - try_hexes = 1
       - #surfcurvfact: 2
       - #chartdistfact: 1.2
       - #edgeanglefact: 1


### PR DESCRIPTION
MeshingParameters::parallel_meshing -> Ng_Meshing_Parameters::parallel_meshing
MeshingParameters::opterrpow -> Ng_Meshing_Parameters::opterrpow
MeshingParameters::delaunayenable -> Ng_Meshing_Parameters::delaunayenable
MeshingParameters::blockfill -> Ng_Meshing_Parameters::blockfillenable
MeshingParameters::filldist -> Ng_Meshing_Parameters::blockfilldist
MeshingParameters::maxoutersteps -> Ng_Meshing_Parameters::maxoutersteps
MeshingParameters::only3D_domain_nr -> Ng_Meshing_Parameters::only3D_domain_nr
MeshingParameters::try_hexes -> Ng_Meshing_Parameters::try_hexes
MeshingParameters::closeedgefac -> Ng_Meshing_Parameters::closedgeenable, Ng_Meshing_Parameters::closedgefact